### PR TITLE
[AWN-84366] - Allow root user to run greenbone-nvt-sync

### DIFF
--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -163,19 +163,6 @@ get_feed_info ()
   fi
 }
 
-# Prevent that root executes this script
-if [ "`id -u`" -eq "0" ]
-then
-  stderr_write "$0 must not be executed as privileged user root"
-  stderr_write
-  stderr_write "Unlike the actual scanner the sync routine does not need privileges."
-  stderr_write "Accidental execution as root would prevent later overwriting of"
-  stderr_write "files with a non-privileged user."
-
-  log_err "Denied to run as root"
-  exit 1
-fi
-
 # Always try to get the information when started.
 # This also ensures variables like FEED_PRESENT are set.
 get_feed_info


### PR DESCRIPTION
Remove the guard that denies root user running `greenbone-nvt-sync`.
Testing:
Rebuilt the `openvas-scanner` locally and installed the debian on rtkbox.
Verified that the guard has been removed from `greenbone-nvt-sync` and root user was able to run the nvt sync.